### PR TITLE
Better mem reporting, track and report per test 

### DIFF
--- a/custom/benchmark/benchmarkUtils.cfc
+++ b/custom/benchmark/benchmarkUtils.cfc
@@ -130,9 +130,9 @@ component  {
 		};
 	}
 
-	numeric getTotalMemoryUsage( usage ){
+	function getTotalMemoryUsage( struct usage ){
 		var memory = 0;
-		for ( m in arguments.usage ){
+		for ( var m in arguments.usage ){
 			if ( isNumeric( arguments.usage[ m ] ) )
 				memory += arguments.usage[ m ];
 		}

--- a/custom/benchmark/benchmarkUtils.cfc
+++ b/custom/benchmark/benchmarkUtils.cfc
@@ -172,8 +172,8 @@ component  {
 			}
 		); // fastest to slowest
 
-		var hdr = [ "Version", "Java", "Time" ];
-		var div = [ "---", "---", "---:" ];
+		var hdr = [ "Version", "Java", "Time", "Memory" ];
+		var div = [ "---", "---", "---:", "---:" ];
 		_logger( "" );
 		_logger( "|" & arrayToList( hdr, "|" ) & "|" );
 		_logger( "|" & arrayToList( div, "|" ) & "|" );
@@ -184,6 +184,7 @@ component  {
 				ArrayAppend( row, run.version );
 				ArrayAppend( row, run.java );
 				arrayAppend( row, numberFormat( run.totalDuration ) );
+				arrayAppend( row, numberFormat( run.memory ) );
 				_logger( "|" & arrayToList( row, "|" ) & "|" );
 				row = [];
 			}

--- a/custom/benchmark/benchmarkUtils.cfc
+++ b/custom/benchmark/benchmarkUtils.cfc
@@ -130,6 +130,15 @@ component  {
 		};
 	}
 
+	numeric getTotalMemoryUsage( usage ){
+		var memory = 0;
+		for ( m in arguments.usage ){
+			if ( isNumeric( arguments.usage[ m ] ) )
+				memory += arguments.usage[ m ];
+		}
+		return int( memory / 1024 / 1024 );
+	}
+
 	function getImageBase64( img ){
 		saveContent variable="local.x" {
 			imageWriteToBrowser( arguments.img );

--- a/custom/benchmark/benchmarkUtils.cfc
+++ b/custom/benchmark/benchmarkUtils.cfc
@@ -58,7 +58,7 @@ component  {
 					querySetCell( q, "_perc", "-#abs(q._perc)#", q.currentRow ) ;
 			}
 			loop list=q.columnlist item="local.col" {
-				if ( col eq "memory" or col eq "time" or col eq "throughput" )
+				if ( col eq "memory" or col eq "time" or col eq "throughput" or col eq "gc" )
 					arrayAppend( row, numberFormat( q [ col ] ) );
 				else if ( col eq "_perc" )
 					arrayAppend( row, numberFormat( q [ col ] ) & "%");

--- a/custom/benchmark/benchmarkUtils.cfc
+++ b/custom/benchmark/benchmarkUtils.cfc
@@ -160,6 +160,16 @@ component  {
 		return false;
 	}
 
+	function getGcCount(){
+		var javaManagementFactory = createObject( "java", "java.lang.management.ManagementFactory" );
+		var gcBeans =javaManagementFactory.getGarbageCollectorMXBeans();
+		var n = 0 ;
+		for (var gc in gcBeans){
+			var n = n + gc.getCollectionCount();
+		}
+		return n;
+	}
+
 	function reportRuns( srcRuns, java="" ) localmode=true {
 
 		var runs = duplicate( srcRuns );
@@ -172,8 +182,8 @@ component  {
 			}
 		); // fastest to slowest
 
-		var hdr = [ "Version", "Java", "Time", "Memory" ];
-		var div = [ "---", "---", "---:", "---:" ];
+		var hdr = [ "Version", "Java", "Time", "Memory", "GCs" ];
+		var div = [ "---", "---", "---:", "---:", "---:" ];
 		_logger( "" );
 		_logger( "|" & arrayToList( hdr, "|" ) & "|" );
 		_logger( "|" & arrayToList( div, "|" ) & "|" );
@@ -185,6 +195,7 @@ component  {
 				ArrayAppend( row, run.java );
 				arrayAppend( row, numberFormat( run.totalDuration ) );
 				arrayAppend( row, numberFormat( run.memory ) );
+				arrayAppend( row, numberFormat( run.gcCount ) );
 				_logger( "|" & arrayToList( row, "|" ) & "|" );
 				row = [];
 			}

--- a/custom/benchmark/index.cfm
+++ b/custom/benchmark/index.cfm
@@ -116,6 +116,8 @@
 				if (exeLog eq "debug") {
 					exeLogger.purgeExecutionLog();
 				}
+				createObject( "java", "java.lang.System" ).gc();
+				testMemStatStart = reportMem( "", {}, "before", "HEAP" );
 			
 				ArrayEach( arr, function( item, idx, _arr ){
 					if (runAborted) return;
@@ -132,6 +134,7 @@
 						 throw mess;
 					}
 				}, true);
+
 			} catch ( _e ){
 				e = benchmarkUtils.cleanException(_e);
 				lastOkRound = arrayFind(arr, function(item) { return item != 0; });
@@ -144,6 +147,7 @@
 				runError = e.message;
 				errorCount++;
 			}
+			testMemStatEnd = reportMem( "", testMemStatStart.usage, "before", "HEAP" );
 
 			time = getTickCount( units ) - s;
 
@@ -152,6 +156,7 @@
 				time: time / 1000,
 				inspect: inspect,
 				type: type,
+				testMemory: benchmarkUtils.getMemoryUsage( testMemStatEnd.usage ),
 				_min: decimalFormat( arrayMin( arr ) / 1000 ),
 				_max: decimalFormat( arrayMax( arr ) / 1000 ),
 				_avg: decimalFormat( arrayAvg( arr ) / 1000 ),

--- a/custom/benchmark/index.cfm
+++ b/custom/benchmark/index.cfm
@@ -149,7 +149,7 @@
 			}
 			// note this is without doing a GC
 			testMemStatEnd = reportMem( "", testMemStatStart.usage, "before", "HEAP" );
-			testMemoryUsage =  benchmarkUtils.getMemoryUsage( testMemStatEnd.usage );
+			testMemoryUsage =  benchmarkUtils.getTotalMemoryUsage( testMemStatEnd.usage );
 			time = getTickCount( units ) - s;
 
 			_logger( "Finished #suiteName# [#numberFormat( runs/1000 )#k-#inspect#] took #numberFormat( time/1000 )# ms, "

--- a/custom/benchmark/index.cfm
+++ b/custom/benchmark/index.cfm
@@ -118,6 +118,7 @@
 				}
 				createObject( "java", "java.lang.System" ).gc();
 				testMemStatStart = reportMem( "", {}, "before", "HEAP" );
+				testGCStart = benchmarkUtils.getGcCount();
 			
 				ArrayEach( arr, function( item, idx, _arr ){
 					if (runAborted) return;
@@ -150,6 +151,7 @@
 			// note this is without doing a GC
 			testMemStatEnd = reportMem( "", testMemStatStart.usage, "before", "HEAP" );
 			testMemoryUsage =  benchmarkUtils.getTotalMemoryUsage( testMemStatEnd.usage );
+			testGCCount = benchmarkUtils.getGcCount() - testGCStart;
 			time = getTickCount( units ) - s;
 
 			_logger( "Finished #suiteName# [#numberFormat( runs/1000 )#k-#inspect#] took #numberFormat( time/1000 )# ms, "
@@ -161,6 +163,7 @@
 				inspect: inspect,
 				type: type,
 				testMemory: testMemoryUsage,
+				gcCount: testGCCount,
 				_min: decimalFormat( arrayMin( arr ) / 1000 ),
 				_max: decimalFormat( arrayMax( arr ) / 1000 ),
 				_avg: decimalFormat( arrayAvg( arr ) / 1000 ),
@@ -201,6 +204,7 @@
 		_logger( r );
 	_logger( "" );
 
+	results.gcCount = benchmarkUtils.getGcCount();
 	results.memory=_memStat;
 	dir = getDirectoryFromPath( getCurrentTemplatePath() ) & "artifacts/";
 	if (!directoryExists( dir ))

--- a/custom/benchmark/index.cfm
+++ b/custom/benchmark/index.cfm
@@ -147,16 +147,20 @@
 				runError = e.message;
 				errorCount++;
 			}
+			// note this is without doing a GC
 			testMemStatEnd = reportMem( "", testMemStatStart.usage, "before", "HEAP" );
-
+			testMemoryUsage =  benchmarkUtils.getMemoryUsage( testMemStatEnd.usage );
 			time = getTickCount( units ) - s;
 
-			_logger( "Finished #suiteName# [#numberFormat( runs/1000 )#k-#inspect#] took #numberFormat( time/1000 )# ms, or #numberFormat(runs/(time/1000/1000))# per second" );
+			_logger( "Finished #suiteName# [#numberFormat( runs/1000 )#k-#inspect#] took #numberFormat( time/1000 )# ms, "
+				& "or #numberFormat(runs/(time/1000/1000))# per second, "
+				& "using #numberFormat(testMemoryUsage)# Mb"
+			);
 			result = {
 				time: time / 1000,
 				inspect: inspect,
 				type: type,
-				testMemory: benchmarkUtils.getMemoryUsage( testMemStatEnd.usage ),
+				testMemory: testMemoryUsage,
 				_min: decimalFormat( arrayMin( arr ) / 1000 ),
 				_max: decimalFormat( arrayMax( arr ) / 1000 ),
 				_avg: decimalFormat( arrayAvg( arr ) / 1000 ),

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -15,8 +15,7 @@
 
 		json.run.java = listFirst( json.run.java, "." );
 		json.run.memory = benchmarkUtils.getTotalMemoryUsage( json.memory.usage );
-		json.run.gcCount = json.gcCount;
-
+		
 		for ( r in json.data ){
 			StructAppend( r, json.run );
 			r.throughput = int( r.runs / ( r.time / 1000 ) );
@@ -38,7 +37,7 @@
 			"version": json.run.version,
 			"totalDuration": json.run.totalDuration,
 			"memory": json.run.memory,
-			"gcCount": json.run.gcCount
+			"gcCount": json.gcCount
 		});
 	}
 

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -3,7 +3,7 @@
 	dir = getDirectoryFromPath( getCurrentTemplatePath() ) & "artifacts";
 	files = directoryList( dir );
 
-	q = queryNew( "version,java,type,time,runs,inspect,memory,testMemory,throughput,"
+	q = queryNew( "version,java,type,time,runs,inspect,memory,testMemory,gccount,throughput,"
 		& "_min,_max,_avg,_med,error,raw,_perc,exeLog,totalDuration" );
 
 	tests = structNew('ordered');
@@ -37,7 +37,8 @@
 			"java": json.run.java,
 			"version": json.run.version,
 			"totalDuration": json.run.totalDuration,
-			"memory": json.run.memory
+			"memory": json.run.memory,
+			"gcCount": json.run.gcCount
 		});
 	}
 
@@ -116,7 +117,7 @@
 			```
 			<cfquery name="q_rpt" dbtype="query">
 				select	version, java, time,
-						throughput, _perc, _min, _avg, _med, _max, error, testMemory as memory
+						throughput, _perc, _min, _avg, _med, _max, error, testMemory as memory, gccount as _gc
 				from	q
 				where	type = <cfqueryparam value="#type#">
 						and inspect = <cfqueryparam value="#inspect#">

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -116,7 +116,7 @@
 			```
 			<cfquery name="q_rpt" dbtype="query">
 				select	version, java, time,
-						throughput, _perc, _min, _avg, _med, _max, error, testMemory as memory, gccount as _gc
+						throughput, _perc, _min, _avg, _med, _max, error, testMemory as memory, gccount as gc
 				from	q
 				where	type = <cfqueryparam value="#type#">
 						and inspect = <cfqueryparam value="#inspect#">

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -14,8 +14,8 @@
 		json = deserializeJson( fileRead( f ) );
 
 		json.run.java = listFirst( json.run.java, "." );
-
 		json.run.memory = benchmarkUtils.getTotalMemoryUsage( json.memory.usage );
+		json.run.gcCount = json.gcCount;
 
 		for ( r in json.data ){
 			StructAppend( r, json.run );

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -36,7 +36,8 @@
 		arrayAppend( runs, {
 			"java": json.run.java,
 			"version": json.run.version,
-			"totalDuration": json.run.totalDuration
+			"totalDuration": json.run.totalDuration,
+			"memory": json.run.memory
 		});
 	}
 

--- a/custom/benchmark/report.cfm
+++ b/custom/benchmark/report.cfm
@@ -1,8 +1,9 @@
 <cfscript>
+	benchmarkUtils = new benchmarkUtils();
 	dir = getDirectoryFromPath( getCurrentTemplatePath() ) & "artifacts";
 	files = directoryList( dir );
 
-	q = queryNew( "version,java,type,time,runs,inspect,memory,throughput,"
+	q = queryNew( "version,java,type,time,runs,inspect,memory,testMemory,throughput,"
 		& "_min,_max,_avg,_med,error,raw,_perc,exeLog,totalDuration" );
 
 	tests = structNew('ordered');
@@ -14,12 +15,7 @@
 
 		json.run.java = listFirst( json.run.java, "." );
 
-		memory = 0;
-		for ( m in json.memory.usage ){
-			if ( isNumeric( json.memory.usage[ m ] ) )
-				memory += json.memory.usage[ m ];
-		}
-		json.run.memory = int( memory / 1024 / 1024 );
+		json.run.memory = benchmarkUtils.getTotalMemoryUsage( json.memory.usage );
 
 		for ( r in json.data ){
 			StructAppend( r, json.run );
@@ -44,7 +40,7 @@
 		});
 	}
 
-	benchmarkUtils = new benchmarkUtils();
+	
 	_logger= benchmarkUtils._logger;
 
 	filter = benchmarkUtils.getTests( server.system.environment.BENCHMARK_FILTER ?: "");
@@ -119,7 +115,7 @@
 			```
 			<cfquery name="q_rpt" dbtype="query">
 				select	version, java, time,
-						throughput, _perc, _min, _avg, _med, _max, memory, error
+						throughput, _perc, _min, _avg, _med, _max, error, testMemory as memory
 				from	q
 				where	type = <cfqueryparam value="#type#">
 						and inspect = <cfqueryparam value="#inspect#">


### PR DESCRIPTION
previously we were only tracking memory usage across the whole suite, but citing them for each test run, which was misleading

this tracks the memory usage for each test run, doing a GC before each test
as well as the number of GC which occurred

